### PR TITLE
Flexible window conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,37 @@ local function on_attach(bufnr)
     vim.keymap.set("n", "r", float_close_wrap(api.fs.rename), opts("Rename"))
 end
 ```
+
+## Configure Window Size
+
+You can augment the window config by adding arguments to be passed to `nvim_open_win` by providing a `window.open_win_config`. This can be either a table or a function that returns a table.
+
+```lua
+require('float-preview').setup({
+    window =  {
+        wrap = false,
+        trim_height = false,
+        open_win_config = function()
+            local screen_w = vim.opt.columns:get()
+            local screen_h = vim.opt.lines:get() - vim.opt.cmdheight:get()
+            local window_w_f = (screen_w - WIDTH_PADDING * 2 -1) / 2
+            local window_w = math.floor(window_w_f)
+            local window_h = screen_h - HEIGHT_PADDING * 2
+            local center_x = window_w_f + WIDTH_PADDING + 2
+            local center_y = ((vim.opt.lines:get() - window_h) / 2) - vim.opt.cmdheight:get()
+
+            return {
+                style = "minimal",
+                relative = "editor",
+                border = "single",
+                row = center_y,
+                col = center_x,
+                width = window_w,
+                height = window_h
+            }
+        end
+    }
+})
+
+```
+

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ end
 You can augment the window config by adding arguments to be passed to `nvim_open_win` by providing a `window.open_win_config`. This can be either a table or a function that returns a table.
 
 ```lua
+HEIGHT_PADDING = 10
+WIDTH_PADDING = 15
 require('float-preview').setup({
     window =  {
         wrap = false,
@@ -114,4 +116,6 @@ require('float-preview').setup({
 })
 
 ```
+
+<img src="https://github.com/haondt/nvim-tree.lua-float-preview/assets/19233365/f71aede5-068b-4a13-b3ca-bd373de40ff6" width="800">
 

--- a/doc/nvim-tree.lua-float-preview.txt
+++ b/doc/nvim-tree.lua-float-preview.txt
@@ -74,7 +74,7 @@ Float window options
   Style of window
   Type: `string`, Default: `minimal`
 
-  *float-preview.window..relative*
+  *float-preview.window.relative*
   Type: `string`, Default: `win`
 
   *float-preview.window.border*

--- a/doc/nvim-tree.lua-float-preview.txt
+++ b/doc/nvim-tree.lua-float-preview.txt
@@ -74,16 +74,24 @@ Float window options
   Style of window
   Type: `string`, Default: `minimal`
 
-  *float-preview.relative*
+  *float-preview.window..relative*
   Type: `string`, Default: `win`
 
-  *float-preview.border*
+  *float-preview.window.border*
   Type: `string`, Default: `rounded`
 
-  *float-preview.wrap*
+  *float-preview.window.wrap*
   wrap lines inside window
   Type: `boolean`, Default: `false`
 
+  *float-preview.window.trim_height*
+  trim window height when file has fewer lines than configured window height
+  Type: `boolean`, Default: `true`
+
+  *float-preview.window.open_win_config*
+  Additional floating window config. See |nvim_open_win| for more details.
+  Type: `table | function` returning a table
+  Default: `nil`
 
 *float-preview.mapping*
 Mapping for manipulate float window if focus on nvim-tree.

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -146,6 +146,11 @@ function FloatPreview:preview(path)
   vim.api.nvim_set_option_value("buftype", "nowrite", { buf = self.buf })
   vim.api.nvim_set_option_value("buflisted", false, { buf = self.buf })
 
+  local cfg_window = self.cfg.window
+  if type(cfg_window) == "function" then
+    cfg_window = cfg_window()
+  end
+
   local width = vim.api.nvim_get_option "columns"
   local height = vim.api.nvim_get_option "lines"
   local prev_height = math.ceil(height / 2)
@@ -156,10 +161,12 @@ function FloatPreview:preview(path)
     col = vim.fn.winwidth(0) + 1,
     focusable = false,
     noautocmd = true,
-    style = self.cfg.window.style,
-    relative = self.cfg.window.relative,
-    border = self.cfg.window.border,
   }
+
+  for k, v in pairs(cfg_window) do
+    opts[k] = v
+  end
+
   self.win = vim.api.nvim_open_win(self.buf, true, opts)
   vim.api.nvim_set_option_value("wrap", self.cfg.window.wrap, { win = self.win })
 

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -168,7 +168,7 @@ function FloatPreview:preview(path)
   end
 
   self.win = vim.api.nvim_open_win(self.buf, true, opts)
-  vim.api.nvim_set_option_value("wrap", self.cfg.window.wrap, { win = self.win })
+  vim.api.nvim_set_option_value("wrap", cfg_window.wrap, { win = self.win })
 
   read_file_async(
     path,

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -146,11 +146,6 @@ function FloatPreview:preview(path)
   vim.api.nvim_set_option_value("buftype", "nowrite", { buf = self.buf })
   vim.api.nvim_set_option_value("buflisted", false, { buf = self.buf })
 
-  local cfg_window = self.cfg.window
-  if type(cfg_window) == "function" then
-    cfg_window = cfg_window()
-  end
-
   local width = vim.api.nvim_get_option "columns"
   local height = vim.api.nvim_get_option "lines"
   local prev_height = math.ceil(height / 2)
@@ -161,14 +156,24 @@ function FloatPreview:preview(path)
     col = vim.fn.winwidth(0) + 1,
     focusable = false,
     noautocmd = true,
+    style = self.cfg.window.style,
+    relative = self.cfg.window.relative,
+    border = self.cfg.window.border,
   }
 
-  for k, v in pairs(cfg_window) do
-    opts[k] = v
+  local open_win_config = self.cfg.window.open_win_config
+  if type(open_win_config) == "function" then
+    open_win_config = open_win_config()
+  end
+
+  if open_win_config then
+    for k, v in pairs(open_win_config) do
+      opts[k] = v
+    end
   end
 
   self.win = vim.api.nvim_open_win(self.buf, true, opts)
-  vim.api.nvim_set_option_value("wrap", cfg_window.wrap, { win = self.win })
+  vim.api.nvim_set_option_value("wrap", self.cfg.window.wrap, { win = self.win })
 
   read_file_async(
     path,
@@ -181,10 +186,12 @@ function FloatPreview:preview(path)
         table.remove(lines)
       end
       self.max_line = #lines
-      if self.max_line < prev_height then
-        opts.height = self.max_line + 1
-        opts.noautocmd = nil
-        vim.api.nvim_win_set_config(self.win, opts)
+      if self.cfg.window.trim_height then
+        if self.max_line < prev_height then
+          opts.height = self.max_line + 1
+          opts.noautocmd = nil
+          vim.api.nvim_win_set_config(self.win, opts)
+        end
       end
       vim.api.nvim_buf_set_lines(self.buf, 0, -1, false, lines)
 

--- a/lua/float-preview/config.lua
+++ b/lua/float-preview/config.lua
@@ -8,6 +8,7 @@ local CFG = {
       relative = "win",
       border = "rounded",
       wrap = false,
+      trim_height = true,
     },
     mapping = {
       -- scroll down float buffer


### PR DESCRIPTION
- adds `window.trim_height` to allow for a constant sized window regardless of content
- adds `window.open_win_config`, which can be a table **or** a function that generates a table. This table will be passed to the neovim window creation funciton. 

This allows for the window size to be configured when the tree is opened, which is nice for floating views.

![image](https://github.com/haondt/nvim-tree.lua-float-preview/assets/19233365/ff7786ce-88e0-4d71-b993-47ad0a6c39a4)
