### PR TITLE
feat: Add an option to disable the preview by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Example
             lazy = true,
             -- default
             opts = {
+                -- Whether the float preview is enabled by default. When set to false, it has to be "toggled" on.
+                toggled_on = true,
                 -- wrap nvimtree commands
                 wrap_nvimtree_commands = true,
                 -- lines for scroll

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -72,6 +72,8 @@ function FloatPreview.setup(cfg)
 
   cfg = CFG.config()
 
+  disabled = not cfg.toggled_on
+
   if cfg.wrap_nvimtree_commands then
     api.node.open.tab = FloatPreview.close_wrap(api.node.open.tab)
     api.node.open.vertical = FloatPreview.close_wrap(api.node.open.vertical)

--- a/lua/float-preview/config.lua
+++ b/lua/float-preview/config.lua
@@ -1,5 +1,7 @@
 local CFG = {
   _cfg = {
+    -- Whether the float preview is enabled by default. When set to false, it has to be "toggled" on.
+    toggled_on = true,
     -- wrap nvimtree commands
     wrap_nvimtree_commands = true,
     -- lines for scroll


### PR DESCRIPTION
I find it distracting, when the previews pop up by default. I prefer to toggle it on manually.