### PR TITLE
Feat/enable preview with key

### DIFF
--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -328,10 +328,15 @@ function FloatPreview:attach(bufnr)
     self:preview_under_cursor()
   end
 
-  vim.api.nvim_create_user_command("ToggleFilePreview", toggle_preview, { buffer = bufnr })
-
   local au = {}
-
+  table.insert(
+    au,
+    vim.api.nvim_create_autocmd("BufEnter", {
+      callback = function()
+        vim.api.nvim_create_user_command("TogglePreviewFile", toggle_preview, { buffer = bufnr })
+      end,
+    })
+  )
   table.insert(
     au,
     vim.api.nvim_create_autocmd({ "CursorHold" }, {

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -333,8 +333,11 @@ function FloatPreview:attach(bufnr)
   table.insert(
     au,
     vim.api.nvim_create_autocmd("BufDelete", {
+      group = preview_au,
       callback = function()
-        vim.api.nvim_del_user_command "TogglePreviewFile"
+        if vim.fn.exists ":TogglePreviewFile" > 0 then
+          vim.api.nvim_del_user_command "TogglePreviewFile"
+        end
       end,
     })
   )

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -328,7 +328,7 @@ function FloatPreview:attach(bufnr)
     for _, key in ipairs(self.cfg.mapping.preview) do
       vim.keymap.set("n", key, function()
         local _, node = pcall(get_node)
-        if self.path ~= nil and self.path == node.path then
+        if self.path ~= nil and self.path == node.absolute_path then
           self.close_preview(self)
           return
         end
@@ -347,9 +347,11 @@ function FloatPreview:attach(bufnr)
         if self.cfg.auto_preview then
           if bufnr == vim.api.nvim_get_current_buf() then
             self:preview_under_cursor()
-          else
-            self:_close "changed buffer"
+            return
           end
+
+          self:_close "changed buffer"
+          return
         end
       end,
     })
@@ -360,12 +362,7 @@ function FloatPreview:attach(bufnr)
     vim.api.nvim_create_autocmd({ "CursorMoved" }, {
       group = preview_au,
       callback = function()
-        local _, node = pcall(get_node)
-        if self.path == node.path then
-          self.close_preview(self)
-          return
-        end
-        self.close_preview(self)
+        self:close_preview()
       end,
     })
   )

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -332,7 +332,8 @@ function FloatPreview:attach(bufnr)
       vim.keymap.set("n", key, function()
         local _, node = pcall(get_node)
         if self.path ~= nil and self.path == node.path then
-          self.close_preview(self)
+          -- self.close_preview(self)
+          self:_close "toggle preview"
           return
         end
 

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -302,9 +302,6 @@ function FloatPreview:close_preview()
     return
   end
 
-  if node.absolute_path == self.path then
-    return
-  end
   self:_close "cursor moved"
 end
 
@@ -332,8 +329,7 @@ function FloatPreview:attach(bufnr)
       vim.keymap.set("n", key, function()
         local _, node = pcall(get_node)
         if self.path ~= nil and self.path == node.path then
-          -- self.close_preview(self)
-          self:_close "toggle preview"
+          self.close_preview(self)
           return
         end
 

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -258,11 +258,7 @@ function FloatPreview:preview_under_cursor()
   if not node then
     return
   end
-
-  if node.absolute_path == self.path then
-    return
-  end
-  self:_close "change file"
+  self.close_preview(self)
 
   if node.type ~= "file" then
     return
@@ -278,13 +274,6 @@ function FloatPreview:preview_under_cursor()
 end
 
 function FloatPreview:scroll(line)
-  local _, node = pcall(get_node)
-  if not node then
-    return
-  end
-  if node.absolute_path == self.path then
-    self:_close "change file"
-  end
   if self.win then
     local ok, _ = pcall(vim.api.nvim_win_set_cursor, self.win, { line, 0 })
     if ok then
@@ -305,6 +294,18 @@ function FloatPreview:scroll_up()
     local next_line = math.max(self.current_line - self.cfg.scroll_lines, 1)
     self:scroll(next_line)
   end
+end
+
+function FloatPreview:close_preview()
+  local _, node = pcall(get_node)
+  if not node then
+    return
+  end
+
+  if node.absolute_path == self.path then
+    return
+  end
+  self:_close "cursor moved"
 end
 
 function FloatPreview:attach(bufnr)
@@ -347,6 +348,21 @@ function FloatPreview:attach(bufnr)
             self:_close "changed buffer"
           end
         end
+      end,
+    })
+  )
+
+  table.insert(
+    au,
+    vim.api.nvim_create_autocmd("CursorMoved", {
+      group = preview_au,
+      callback = function()
+        local _, node = pcall(get_node)
+        if self.path == node.path then
+          self.close_preview(self)
+          return
+        end
+        self.close_preview(self)
       end,
     })
   )

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -67,6 +67,17 @@ local function all_open()
   end
 end
 
+local function toggle_or_preview()
+  local node = api.tree.get_node_under_cursor()
+  if not node then
+    return
+  end
+
+  if node.type ~= "file" then
+    api.node.open.edit() -- Toggle folder
+  end
+end
+
 function FloatPreview.setup(cfg)
   CFG.update(cfg)
 
@@ -75,11 +86,16 @@ function FloatPreview.setup(cfg)
   disabled = not cfg.toggled_on
 
   if cfg.wrap_nvimtree_commands then
+    if cfg.preview_on_bakground then
+      api.node.open.preview = FloatPreview.close_wrap(api.node.open.preview)
+    else
+      api.node.open.preview = toggle_or_preview -- disable the
+    end
+
     api.node.open.tab = FloatPreview.close_wrap(api.node.open.tab)
     api.node.open.vertical = FloatPreview.close_wrap(api.node.open.vertical)
     api.node.open.horizontal = FloatPreview.close_wrap(api.node.open.horizontal)
     api.node.open.edit = FloatPreview.close_wrap(api.node.open.edit)
-    api.node.open.preview = FloatPreview.close_wrap(api.node.open.preview)
     api.node.open.no_window_picker = FloatPreview.close_wrap(api.node.open.no_window_picker)
     api.fs.create = FloatPreview.close_wrap(api.fs.create)
     api.fs.remove = FloatPreview.close_wrap(api.fs.remove)
@@ -137,9 +153,6 @@ end
 
 function FloatPreview:_close(reason)
   if self.path ~= nil and self.buf ~= nil then
-    if reason then
-      -- vim.notify(string.format("fp close %s", reason))
-    end
     pcall(vim.api.nvim_win_close, self.win, { force = true })
     pcall(vim.api.nvim_buf_delete, self.buf, { force = true })
     self.win = nil
@@ -305,21 +318,34 @@ function FloatPreview:attach(bufnr)
       FloatPreview.toggle()
     end, { buffer = bufnr })
   end
+
+  for _, key in ipairs(self.cfg.mapping.preview) do
+    vim.keymap.set("n", key, function()
+      if bufnr == vim.api.nvim_get_current_buf() then
+        self:preview_under_cursor()
+      else
+        self:_close "changed buffer"
+      end
+    end, { buffer = bufnr })
+  end
+
   local au = {}
 
-  table.insert(
-    au,
-    vim.api.nvim_create_autocmd({ "CursorHold" }, {
-      group = preview_au,
-      callback = function()
-        if bufnr == vim.api.nvim_get_current_buf() then
-          self:preview_under_cursor()
-        else
-          self:_close "changed buffer"
-        end
-      end,
-    })
-  )
+  if self.cfg.auto_preview then
+    table.insert(
+      au,
+      vim.api.nvim_create_autocmd({ "CursorHold" }, {
+        group = preview_au,
+        callback = function()
+          if bufnr == vim.api.nvim_get_current_buf() then
+            self:preview_under_cursor()
+          else
+            self:_close "changed buffer"
+          end
+        end,
+      })
+    )
+  end
 
   api.events.subscribe(Event.TreeClose, function(opts)
     if not self then

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -278,6 +278,13 @@ function FloatPreview:preview_under_cursor()
 end
 
 function FloatPreview:scroll(line)
+  local _, node = pcall(get_node)
+  if not node then
+    return
+  end
+  if node.absolute_path == self.path then
+    self:_close "change file"
+  end
   if self.win then
     local ok, _ = pcall(vim.api.nvim_win_set_cursor, self.win, { line, 0 })
     if ok then
@@ -319,14 +326,13 @@ function FloatPreview:attach(bufnr)
     end, { buffer = bufnr })
   end
 
-  for _, key in ipairs(self.cfg.mapping.preview) do
-    vim.keymap.set("n", key, function()
-      if self.cfg.mapping.preview then
-        self.cfg.auto_preview = true
-      end
-    end, { buffer = bufnr })
+  if self.cfg.mapping.preview then
+    for _, key in ipairs(self.cfg.mapping.preview) do
+      vim.keymap.set("n", key, function()
+        self:preview_under_cursor()
+      end, { buffer = bufnr })
+    end
   end
-
   local au = {}
 
   table.insert(

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -330,6 +330,12 @@ function FloatPreview:attach(bufnr)
   if self.cfg.mapping.preview then
     for _, key in ipairs(self.cfg.mapping.preview) do
       vim.keymap.set("n", key, function()
+        local _, node = pcall(get_node)
+        if self.path == node.path then
+          self.close_preview(self)
+          return
+        end
+
         self:preview_under_cursor()
       end, { buffer = bufnr })
     end
@@ -354,7 +360,7 @@ function FloatPreview:attach(bufnr)
 
   table.insert(
     au,
-    vim.api.nvim_create_autocmd("CursorMoved", {
+    vim.api.nvim_create_autocmd({ "CursorMoved" }, {
       group = preview_au,
       callback = function()
         local _, node = pcall(get_node)

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -327,16 +327,17 @@ function FloatPreview:attach(bufnr)
 
     self:preview_under_cursor()
   end
-  vim.api.nvim_create_user_command("TogglePreviewFile", toggle_preview, { buffer = bufnr })
+  vim.api.nvim_create_user_command("TogglePreviewFile", toggle_preview, {})
 
   local au = {}
-  -- table.insert(
-  --   au,
-  --   vim.api.nvim_create_autocmd("BufEnter", {
-  --     callback = function()
-  --     end,
-  --   })
-  -- )
+  table.insert(
+    au,
+    vim.api.nvim_create_autocmd("BufDelete", {
+      callback = function()
+        vim.api.nvim_del_user_command "TogglePreviewFile"
+      end,
+    })
+  )
   table.insert(
     au,
     vim.api.nvim_create_autocmd({ "CursorHold" }, {

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -331,7 +331,7 @@ function FloatPreview:attach(bufnr)
     for _, key in ipairs(self.cfg.mapping.preview) do
       vim.keymap.set("n", key, function()
         local _, node = pcall(get_node)
-        if self.path == node.path then
+        if self.path ~= nil and self.path == node.path then
           self.close_preview(self)
           return
         end

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -321,31 +321,29 @@ function FloatPreview:attach(bufnr)
 
   for _, key in ipairs(self.cfg.mapping.preview) do
     vim.keymap.set("n", key, function()
-      if bufnr == vim.api.nvim_get_current_buf() then
-        self:preview_under_cursor()
-      else
-        self:_close "changed buffer"
+      if self.cfg.mapping.preview then
+        self.cfg.auto_preview = true
       end
     end, { buffer = bufnr })
   end
 
   local au = {}
 
-  if self.cfg.auto_preview then
-    table.insert(
-      au,
-      vim.api.nvim_create_autocmd({ "CursorHold" }, {
-        group = preview_au,
-        callback = function()
+  table.insert(
+    au,
+    vim.api.nvim_create_autocmd({ "CursorHold" }, {
+      group = preview_au,
+      callback = function()
+        if self.cfg.auto_preview then
           if bufnr == vim.api.nvim_get_current_buf() then
             self:preview_under_cursor()
           else
             self:_close "changed buffer"
           end
-        end,
-      })
-    )
-  end
+        end
+      end,
+    })
+  )
 
   api.events.subscribe(Event.TreeClose, function(opts)
     if not self then

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -86,12 +86,7 @@ function FloatPreview.setup(cfg)
   disabled = not cfg.toggled_on
 
   if cfg.wrap_nvimtree_commands then
-    if cfg.preview_on_bakground then
-      api.node.open.preview = FloatPreview.close_wrap(api.node.open.preview)
-    else
-      api.node.open.preview = toggle_or_preview -- disable the
-    end
-
+    api.node.open.preview = toggle_or_preview -- disable the
     api.node.open.tab = FloatPreview.close_wrap(api.node.open.tab)
     api.node.open.vertical = FloatPreview.close_wrap(api.node.open.vertical)
     api.node.open.horizontal = FloatPreview.close_wrap(api.node.open.horizontal)
@@ -258,7 +253,6 @@ function FloatPreview:preview_under_cursor()
   if not node then
     return
   end
-  self.close_preview(self)
 
   if node.type ~= "file" then
     return
@@ -324,19 +318,18 @@ function FloatPreview:attach(bufnr)
     end, { buffer = bufnr })
   end
 
-  if self.cfg.mapping.preview then
-    for _, key in ipairs(self.cfg.mapping.preview) do
-      vim.keymap.set("n", key, function()
-        local _, node = pcall(get_node)
-        if self.path ~= nil and self.path == node.absolute_path then
-          self.close_preview(self)
-          return
-        end
-
-        self:preview_under_cursor()
-      end, { buffer = bufnr })
+  local toggle_preview = function()
+    local _, node = pcall(get_node)
+    if self.path ~= nil and self.path == node.absolute_path then
+      self.close_preview(self)
+      return
     end
+
+    self:preview_under_cursor()
   end
+
+  vim.api.nvim_create_user_command("ToggleFilePreview", toggle_preview, { buffer = bufnr })
+
   local au = {}
 
   table.insert(

--- a/lua/float-preview.lua
+++ b/lua/float-preview.lua
@@ -327,16 +327,16 @@ function FloatPreview:attach(bufnr)
 
     self:preview_under_cursor()
   end
+  vim.api.nvim_create_user_command("TogglePreviewFile", toggle_preview, { buffer = bufnr })
 
   local au = {}
-  table.insert(
-    au,
-    vim.api.nvim_create_autocmd("BufEnter", {
-      callback = function()
-        vim.api.nvim_create_user_command("TogglePreviewFile", toggle_preview, { buffer = bufnr })
-      end,
-    })
-  )
+  -- table.insert(
+  --   au,
+  --   vim.api.nvim_create_autocmd("BufEnter", {
+  --     callback = function()
+  --     end,
+  --   })
+  -- )
   table.insert(
     au,
     vim.api.nvim_create_autocmd({ "CursorHold" }, {

--- a/lua/float-preview/config.lua
+++ b/lua/float-preview/config.lua
@@ -2,6 +2,9 @@ local CFG = {
   _cfg = {
     -- Whether the float preview is enabled by default. When set to false, it has to be "toggled" on.
     toggled_on = true,
+    -- preview in background
+    preview_on_bakground = false, --can get the default behavior if needed
+    auto_preview = true,
     -- wrap nvimtree commands
     wrap_nvimtree_commands = true,
     -- lines for scroll
@@ -21,6 +24,8 @@ local CFG = {
       up = { "<C-e>", "<C-u>" },
       -- enable/disable float windows
       toggle = { "<C-x>" },
+      -- preview with key
+      preview = nil,
     },
     -- hooks if return false preview doesn't shown
     hooks = {

--- a/lua/float-preview/config.lua
+++ b/lua/float-preview/config.lua
@@ -3,7 +3,6 @@ local CFG = {
     -- Whether the float preview is enabled by default. When set to false, it has to be "toggled" on.
     toggled_on = true,
     -- preview in background
-    preview_on_bakground = false, --can get the default behavior if needed
     auto_preview = true,
     -- wrap nvimtree commands
     wrap_nvimtree_commands = true,
@@ -24,8 +23,6 @@ local CFG = {
       up = { "<C-e>", "<C-u>" },
       -- enable/disable float windows
       toggle = { "<C-x>" },
-      -- preview with key
-      preview = nil,
     },
     -- hooks if return false preview doesn't shown
     hooks = {


### PR DESCRIPTION
Since my nvim-tree is a float window i didnt want <Tab> to make a preview in the background which I fixed. I added a user command to toggle a floating window. I can be added to any key with its initial function, like <Tab>. Plus I added a config `auto_preview` (default = true) to be able to de/activate the auto preview on 'CursorHold'.

refactor: I used the event 'CursorMoved' to close the previous preview window so I can close window more easily when I need to.

I tried to not make any breaking changes.